### PR TITLE
Recognize infix operators in module signatures

### DIFF
--- a/OCaml.tmLanguage
+++ b/OCaml.tmLanguage
@@ -1590,7 +1590,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(val!?)(\s+mutable)?\s+([a-z_][a-zA-Z0-9_']*)\s*(:)</string>
+					<string>(val!?)(\s+mutable)?\s+([a-z_][a-zA-Z0-9_']*|\([=&lt;&gt;@^&amp;+\-*/$%|][|!$%&amp;*+./:&lt;=&gt;?@^~-]*\))\s*(:)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1685,7 +1685,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(external)\s+([a-z_][a-zA-Z0-9_']*)\s*(:)</string>
+					<string>(external)\s+([a-z_][a-zA-Z0-9_']*|\([=&lt;&gt;@^&amp;+\-*/$%|][|!$%&amp;*+./:&lt;=&gt;?@^~-]*\))\s*(:)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
See http://caml.inria.fr/pub/docs/manual-ocaml/modtypes.html, specifically `value-name`.

The regex was copied from `keyword.operator.infix.ocaml`. If there's a better way to reference other regexes, I'd love to do that instead.

Before:
![screen shot 2015-03-07 at 11 09 56 pm](https://cloud.githubusercontent.com/assets/3012/6545005/261edc94-c521-11e4-8e11-6a002994293d.png)

After:
![screen shot 2015-03-07 at 11 10 09 pm](https://cloud.githubusercontent.com/assets/3012/6545006/2f4e5308-c521-11e4-8987-e77d6d41b2f7.png)
