### PR TITLE
Improve highlighting of first class modules

### DIFF
--- a/OCaml.tmLanguage
+++ b/OCaml.tmLanguage
@@ -977,6 +977,42 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>\((val)\s+</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.ocaml</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?:\s+(:)\s+([a-zA-Z_][a-zA-Z0-9_']*))?\)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.optional-parameter.ocaml</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.ocaml</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.module.signature.val.ocaml</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(\()(?=(~[a-z][a-zA-Z0-9_]*:|("(\\"|[^"])*")|[^\(\)~"])+(?&lt;!:)(:&gt;|:(?![:=])))</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
Before:
![screen shot 2015-03-08 at 3 04 18 am](https://cloud.githubusercontent.com/assets/3012/6545408/0ae022b8-c543-11e4-9d29-4e9c382bf6a6.png)

After:
![screen shot 2015-03-08 at 3 04 46 am](https://cloud.githubusercontent.com/assets/3012/6545411/0ec2f13a-c543-11e4-97b7-1f7e52d4469e.png)

Test cases come from http://caml.inria.fr/pub/docs/manual-ocaml/extn.html#sec230

Highlighting on lines 12-14 and 18 are improved. Aside from the coloring, before this fix, `meta.module.signature.val.ocaml` starts matching on the `val` on line 18 and continues until it hits the blank line on line 21, which makes no sense.
