### PR TITLE
Fix: let f ?(f = fun _ -> 1) () = f

### DIFF
--- a/OCaml.tmLanguage
+++ b/OCaml.tmLanguage
@@ -133,7 +133,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;=(\(|\s))(fun)\s</string>
+			<string>(?&lt;=(\W))(fun)\s</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>

--- a/OCaml.tmLanguage
+++ b/OCaml.tmLanguage
@@ -133,7 +133,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(\(|\s)(?=fun\s)</string>
+			<string>(\s)(?=fun\s)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -143,7 +143,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\))</string>
+			<string>(?=\))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>

--- a/OCaml.tmLanguage
+++ b/OCaml.tmLanguage
@@ -133,63 +133,32 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(\s)(?=fun\s)</string>
+			<string>(?&lt;=(\(|\s))(fun)\s</string>
 			<key>beginCaptures</key>
 			<dict>
-				<key>1</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.function.anonymous.ocaml</string>
+					<string>keyword.other.function-definition.ocaml</string>
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=\))</string>
+			<string>(-&gt;)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.function.anonymous.ocaml</string>
+					<string>punctuation.separator.function-definition.ocaml</string>
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>meta.function.anonymous.ocaml</string>
+			<string>meta.function.anonymous.definition.ocaml</string>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>(?&lt;=(\(|\s))(fun)\s</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.function-definition.ocaml</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(-&gt;)</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.function-definition.ocaml</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.function.anonymous.definition.ocaml</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#variables</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
 					<key>include</key>
-					<string>$self</string>
+					<string>#variables</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
```ocaml
let f ?(f = fun _ -> 1) () = f 
```
The piece of code above was incorrectly colorized.
Before this commit, the second parenthesis was capture by the fun
so the optional argument assignement was never ended.

There was a parenthesis "imbalance" in the way anonymous functions
were captured.

I hope that the look-ahead used does not make the syntax coloring
too slow.

Also: Thank you very much for this writing this ! It has been super helpful. 